### PR TITLE
jquery ui .buttonset() changes 

### DIFF
--- a/tw2/jqplugins/ui/samples.py
+++ b/tw2/jqplugins/ui/samples.py
@@ -115,6 +115,8 @@ class DemoButtonSetRadio(ButtonSetRadio):
         {'id':'rb_3', 'label':'BBC3'},
     ]
     checked_item = 'rb_2'
+    # demonstrates acquisition of the selected radio button
+    click = "function(e) {alert($(this).attr('id') + ' : was selected');}"
     
 class DemoButtonSetCheckbox(ButtonSetCheckbox):
     items = [
@@ -123,6 +125,28 @@ class DemoButtonSetCheckbox(ButtonSetCheckbox):
         {'id':'cb_3', 'label':'BBC3'},
         {'id':'cb_4', 'label':'BBC4'},
     ]
+    # demonstrates acquisition of checkbutton settings [checked/unchecked]
+    btn_ids = [i['id'] for i in items]
+    click = '''
+        function(e) {
+            var areChecked = {};
+            var button_ids = new Array(%s);
+            
+            for ( i in button_ids ) {
+                areChecked[button_ids[i]] =  $('#'+button_ids[i]).attr('checked');
+            }
+            
+            alert( $(this).attr('id') + ' : was clicked \\n\\n' +
+                   'contents of variable "areChecked": \\n' +
+                   'cb_1: ' + areChecked['cb_1'] + '\\n' +
+                   'cb_2: ' + areChecked['cb_2'] + '\\n' +
+                   'cb_3: ' + areChecked['cb_3'] + '\\n' +
+                   'cb_4: ' + areChecked['cb_4']
+                   )
+        }
+        ''' % (str(btn_ids)[1:-1])
+        
+        
     
 class DemoDatePickerWidget(DatePickerWidget):
     pass

--- a/tw2/jqplugins/ui/templates/buttonset_checkbox.html
+++ b/tw2/jqplugins/ui/templates/buttonset_checkbox.html
@@ -14,5 +14,13 @@
       <label for="${btn['id']}">${btn['label']}</label>
    </py:for>
 </div>
-<xi:include href="generic_jq_ui_js.html" />
+<script type="text/javascript">
+   $(function() {
+      $("#${w.selector}").${w.jqmethod}(${w.options});
+
+      <py:if test="w.click">
+         $("#${w.selector} input").click(${w.click});
+      </py:if>
+   });
+</script>
 </div>

--- a/tw2/jqplugins/ui/templates/buttonset_checkbox.mak
+++ b/tw2/jqplugins/ui/templates/buttonset_checkbox.mak
@@ -10,5 +10,14 @@
 		<label for="${btn['id']}">${btn['label']}</label>
 		% endfor
 	</div>
-	<%include file="generic_jq_ui_js.mak" />
+	
+	<script type="text/javascript">
+		$(function() {
+			$("#${w.selector}").${w.jqmethod}(${w.options});
+			% if w.click:
+				$("#${w.selector} input").click(${w.click});
+			% endif
+		});
+	</script>
+	
 </div>

--- a/tw2/jqplugins/ui/templates/buttonset_radio.html
+++ b/tw2/jqplugins/ui/templates/buttonset_radio.html
@@ -14,5 +14,13 @@
       <label for="${btn['id']}">${btn['label']}</label>
    </py:for>
 </div>
-<xi:include href="generic_jq_ui_js.html" />
+   <script type="text/javascript">
+      $(function() {
+         $("#${w.selector}").${w.jqmethod}(${w.options});
+
+         <py:if test="w.click">
+            $("#${w.selector} input").click(${w.click});
+         </py:if>
+      });
+   </script>
 </div>

--- a/tw2/jqplugins/ui/templates/buttonset_radio.mak
+++ b/tw2/jqplugins/ui/templates/buttonset_radio.mak
@@ -10,5 +10,12 @@
 		<label for="${btn['id']}">${btn['label']}</label>
 		% endfor
 	</div>
-	<%include file="generic_jq_ui_js.mak" />
+	<script type="text/javascript">
+		$(function() {
+			$("#${w.selector}").${w.jqmethod}(${w.options});
+			% if w.click:
+				$("#${w.selector} input").click(${w.click});
+			% endif
+		});
+	</script>
 </div>


### PR DESCRIPTION
Hi Ralph,

I've found it necessary to amend the templates (genshi+mako) for the radio and checkbox buttonset widgets. 
In a nutshell, a function passed to the widgets using their (inherited) .click property was unusable because of the way that the jquery buttonset is constructed.

I've added some example usage to sample.py which hopefully demonstrates how access which buttons have been clicked/selected.... (I know that it'll serve as useful reference for me at least!)

Regards,
Rob  
