### PR TITLE
Basic events binding.

### DIFF
--- a/tw2/jqplugins/ui/base.py
+++ b/tw2/jqplugins/ui/base.py
@@ -104,7 +104,7 @@ class JQueryUIWidget(twc.Widget):
     events = twc.Param('(dict) (BETA) javascript callbacks for events', default=None)
 
     def prepare(self):
-        if hasattr(self, 'events') and not isinstance(self.events, dict):
+        if self.events is not None and not isinstance(self.events, dict):
             raise ValueError, 'Events parameter must be a dict'
 
         self.resources.append(jquery_ui_css(name=get_ui_theme_name()))


### PR DESCRIPTION
Added some **really** basic code to allow binding events to jQueryUI objects. Requesting comment.

Test Code:

```
class temp_thing(tw2.jqplugins.ui.ButtonWidget):
    type = 'button'
    id = "button"
    events = {
        'click': "function() { alert( 'Hello world!' ) }",
        'focus': "function() { alert ( 'Lost Focus!' ) }",
    }
    options = {
        'label' : "This is a jQuery UI button",
    }
```
