### PR TITLE
Make our html shim emulate unicode, not byte strings.

### DIFF
--- a/tw2/jqplugins/ui/widgets.py
+++ b/tw2/jqplugins/ui/widgets.py
@@ -12,7 +12,7 @@ import types
 import six
 
 
-class html(str):
+class html(six.text_type):
     """ A stand-in used to treat the item contents as 'html-literals' """
     def __html__(self):
         return six.text_type(self)


### PR DESCRIPTION
If we're just returning the unicode value, no reason to unnecessarily
coerce our inputs to byte-strings first.  Use unicode all the way
through.